### PR TITLE
Checks for existing `last_fm_url` before creating `Artist`

### DIFF
--- a/app/Console/Commands/CloneLastFMArtists.php
+++ b/app/Console/Commands/CloneLastFMArtists.php
@@ -121,6 +121,10 @@ class CloneLastFMArtists extends Command
     {
         // LastFM responses are weird
         foreach ($artists as $artist) {
+            if (Artist::where('last_fm_url', $artist->url)->exists()) {
+                continue;
+            }
+
             Artist::create([
                 'name' => $artist->name,
                 'mbid' => $artist->mbid,


### PR DESCRIPTION
https://recc-reborn.atlassian.net/browse/RECC-66

To validate, run
```
php artisan lfm:clone-artists
```
And press <kbd>CTRL</kbd>+<kbd>C</kbd> before the script finishes running to create just some `Artist` records, then run
```
php artisan lfm:clone-artists
```
again to continue cloning artists without errors.