### PR TITLE
Adds the `Playlist` model

### DIFF
--- a/app/Enums/PlaylistOrigin.php
+++ b/app/Enums/PlaylistOrigin.php
@@ -1,0 +1,12 @@
+<?php
+namespace App\Enums;
+
+abstract class PlaylistOrigin
+{
+    // Recommended using favorite artists
+    public const RECOMMENDED_FAVORITES = "RECOMMENDED_FAVORITES";
+    public const RECOMMENDED_HABITS = "RECOMMENDED_HABITS";
+    public const RECOMMENDED_POPULAR = "RECOMMENDED_POPULAR";
+    // Created by a user
+    public const CUSTOM = "CUSTOM";
+}

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Track;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Playlist extends Model
+{
+    use HasFactory;
+
+    /**
+     * Who created the playlist?
+     * Can be null. If so, it was auto-generated
+     */
+    public function creator()
+    {
+        return $this->belongs(User::class);
+    }
+
+    /**
+     * Tracks in this playlist
+     */
+    public function tracks()
+    {
+        return $this->belongsToMany(Track::class);
+    }
+}

--- a/database/factories/PlaylistFactory.php
+++ b/database/factories/PlaylistFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Playlist;
+use App\Enums\PlaylistOrigin;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PlaylistFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Playlist::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'title' => $this->faker->realText($maxNbChars=50),
+            'origin' => PlaylistOrigin::RECOMMENDED_FAVORITES,
+        ];
+    }
+}

--- a/database/migrations/2022_11_16_022208_create_playlists_table.php
+++ b/database/migrations/2022_11_16_022208_create_playlists_table.php
@@ -13,20 +13,22 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::create('playlists', function (Blueprint $table) {
+        Schema::create("playlists", function (Blueprint $table) {
             $table->id();
             $table->timestamps();
             $table->string("title")->nullable();
             $table->string("origin");
-            $table->foreignId('user_id')->constrained()->nullOnDelete();
+            $table->foreignId("user_id")->nullable()->constrained('users')->nullOnDelete();
         });
 
-        // playlist<->song many-to-many relationship
-        Schema::create('playlist_song', function (Blueprint $table) {
-            $table->foreignId('playlist_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('song_id')->constrained()->cascadeOnDelete();
+        // playlist<->track many-to-many relationship
+        Schema::create("playlist_track", function (Blueprint $table) {
+            // describes the order of the tracks in the playlist
+            $table->float("ordinal")->default(0);
+            $table->foreignId("playlist_id")->constrained('playlists')->cascadeOnDelete();
+            $table->foreignId("track_id")->constrained('tracks')->cascadeOnDelete();
         });
-    })
+    }
 
     /**
      * Reverse the migrations.
@@ -35,7 +37,7 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('playlists');
-        Schema::dropIfExists('playlist_song');
+        Schema::dropIfExists("playlists");
+        Schema::dropIfExists("playlist_track");
     }
 };

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder
             UserSeeder::class,
             TracksTableSeeder::class,
             PlaybackSeeder::class,
+            PlaylistSeeder::class,
         ]);
     }
 }

--- a/database/seeders/PlaylistSeeder.php
+++ b/database/seeders/PlaylistSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Playlist;
+use App\Models\Track;
+use Illuminate\Database\Seeder;
+
+class PlaylistSeeder extends Seeder
+{
+    /**
+     * Creates playlists and adds tracks to them
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Playlist::factory()
+            ->count(30)
+            ->create()
+            ->each(function ($playlist) {
+                // take 20 random track IDs and put them into this playlist
+                $randomTrackIds = Track::limit(20)->inRandomOrder()->get()->pluck("id");
+                $playlist->tracks()->attach($randomTrackIds);
+            });
+    }
+}

--- a/database/seeders/TracksTableSeeder.php
+++ b/database/seeders/TracksTableSeeder.php
@@ -14,6 +14,6 @@ class TracksTableSeeder extends Seeder
      */
     public function run()
     {
-        Track::factory()->times(50)->create();
+        Track::factory()->times(200)->create();
     }
 }


### PR DESCRIPTION
https://recc-reborn.atlassian.net/browse/RECC-74

- Adds the `playlists` table.
- Adds a pivot table for the relationship between playlists and tracks `playlist_track`.
- Adds an Eloquent model for `Playlist`.
- Adds a factory and seeders for test playlists.

To validate:
```bash
make start
./vendor/bin/sail artisan db:wipe
make migrate
./vendor/bin/sail artisan db:seed
./vendor/bin/sail artisan tinker
```
Once in the artisan tinker command line:
```php
Playlist::first()->tracks()->take(2)->get()
```
Should return two tracks